### PR TITLE
fix: parameters of prepare ligand and receptor

### DIFF
--- a/gaudi/objectives/vina.py
+++ b/gaudi/objectives/vina.py
@@ -49,7 +49,6 @@ class Vina(ObjectiveProvider):
 
     """
     Vina class
-
     Parameters
     ----------
     receptor : str
@@ -59,7 +58,6 @@ class Vina(ObjectiveProvider):
     prepare_each : bool
         Whether to prepare receptors and ligands in every evaluation or try
         to cache the results for faster performance.
-
     Returns
     -------
     float
@@ -110,8 +108,10 @@ class Vina(ObjectiveProvider):
     def _prepare(self, molecule, which='receptor'):
         if which == 'receptor':
             preparer = AD4ReceptorPreparation
+            kwargs = {"repairs": '', "cleanup": ''}
         elif which == 'ligand':
             preparer = AD4LigandPreparation
+            kwargs = {"repairs": '', "cleanup": '', "inactivate_all_torsions": True}
         else:
             raise ValueError('which must be receptor or ligand')
         path = '{}_{}.pdb'.format(self.tmpfile, which)
@@ -121,7 +121,7 @@ class Vina(ObjectiveProvider):
             self._paths.append(path)
             mol = MolKit.Read(path)[0]
             mol.buildBondsByDistance()
-            RPO = preparer(mol, outputfilename=pathqt)
+            RPO = preparer(mol, outputfilename=pathqt, **kwargs)
             self._paths.append(pathqt)
         else:
             # update coordinates


### PR DESCRIPTION
When using prepare_each = False, the actualization of coordinates in method _update_pdbqt_coordinates is performed assuming that the order of atoms is the same in the chimera and pdqt molecules. 
That was not true, because AD4LigandPreparation and AD4ReceptorPreparation were making changes in the structure of the molecule in order to make some repairs (hydrogens) and clean ups. Now, these functions are called with a parameter configuration that avoids structure modifications of the original molecules.