### PR TITLE
add: surrounding of rotamers is taken into account

### DIFF
--- a/gaudi/objectives/contacts.py
+++ b/gaudi/objectives/contacts.py
@@ -203,7 +203,7 @@ class Contacts(ObjectiveProvider):
         self.zone.add([a for m in self.probes(ind) for a in m.atoms])
 
         #Add beta carbons of rotamers to find clashes in its surroundings
-        rotamer_genes = [name for name, g in ind.genes.items() \
+        rotamer_genes = [name for name, g in ind.genes.items() 
                         if g.__class__.__name__ == 'Rotamers']
         beta_carbons = []
         for n in rotamer_genes:

--- a/gaudi/objectives/contacts.py
+++ b/gaudi/objectives/contacts.py
@@ -195,10 +195,23 @@ class Contacts(ObjectiveProvider):
 
     def _surrounding_atoms(self, ind):
         """
-        Get atoms in the search zone, based on the molecule and the radius
+        Get atoms in the search zone, based on the molecule, (possible) rotamer
+        genes and the radius
         """
         self.zone.clear()
+        #Add all atoms of probes molecules
         self.zone.add([a for m in self.probes(ind) for a in m.atoms])
+
+        #Add beta carbons of rotamers to find clashes in its surroundings
+        rotamer_genes = [name for name, g in ind.genes.items() \
+                        if g.__class__.__name__ == 'Rotamers']
+        beta_carbons = []
+        for n in rotamer_genes:
+            for ((molname, pos), residue) in ind.genes[n].residues.items():
+                beta_carbons.extend([a for a in residue.atoms if a.name == 'CB'])
+        self.zone.add(beta_carbons)
+
+        #Surrounding zone from probes+rotamers atoms
         self.zone.merge(chimera.selection.REPLACE,
                         chimera.specifier.zone(self.zone, 'atom', None,
                                                self.radius, self.molecules(ind)))


### PR DESCRIPTION
If there is some "Rotamers" gene/s, take into account the CB of its/their residues to decide the zone which is object of contacts/clashes evaluation.
Now, the evaluated zone will be all the atoms at a distance <= radius from every atom of the probes and from the CB atoms of the rotamers residues.