### PR TITLE
fix: installation issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 - conda activate
 - conda config --set always_yes yes
 - conda config --remove-key channels || true
-- conda config --add channels anaconda
+- conda config --add channels conda-forge
 - conda config --add channels bioconda
 - conda config --add channels salilab
 - conda config --add channels omnia

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ install:
 - conda activate
 - conda config --set always_yes yes
 - conda config --remove-key channels || true
-- conda config --add channels conda-forge
+- conda config --add channels anaconda
 - conda config --add channels bioconda
 - conda config --add channels salilab
 - conda config --add channels omnia

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 # Requires additional channels:
-#   conda build --python=2.7 -c omnia -c salilab -c insilichem -c conda-forge -c anaconda -c bioconda .
+#   conda build --python=2.7 -c omnia -c salilab -c insilichem -c conda-forge -c bioconda .
 
 package:
   name: gaudi
@@ -39,7 +39,7 @@ requirements:
     - pdbfixer
     - cclib
     - scipy
-    - imp 2.9.*
+    - imp 2.11.*
     - autodock-vina
     # InsiliChem channel
     - autodocktools-prepare

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 # Requires additional channels:
-#   conda build --python=2.7 -c omnia -c salilab -c insilichem -c anaconda -c bioconda .
+#   conda build --python=2.7 -c omnia -c salilab -c insilichem -c conda-forge -c anaconda -c bioconda .
 
 package:
   name: gaudi

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 # Requires additional channels:
-#   conda build --python=2.7 -c insilichem -c bioconda -c conda-forge -c salilab -c omnia -c "$CONDA_PREFIX/conda-bld/" .
+#   conda build --python=2.7 -c omnia -c salilab -c insilichem -c anaconda -c bioconda .
 
 package:
   name: gaudi

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ Quick steps:
 
 ::
 
-  conda create -n gaudi_test -c omnia -c salilab -c insilichem -c anaconda gaudi
+  conda create -n insilichem -c omnia -c salilab -c insilichem -c anaconda gaudi
 
 
 4 - Activate the new environment as proposed:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ Quick steps:
 
 ::
 
-  conda create -n insilichem -c omnia -c salilab -c insilichem -c anaconda gaudi
+  conda create -n insilichem -c omnia -c salilab -c insilichem -c anaconda -c bioconda gaudi
 
 
 4 - Activate the new environment as proposed:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ Quick steps:
 
 ::
 
-  conda create -n insilichem -c omnia -c salilab -c insilichem -c bioconda gaudi
+  conda create -n gaudi_test -c omnia -c salilab -c insilichem -c anaconda gaudi
 
 
 4 - Activate the new environment as proposed:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -46,6 +46,12 @@ Quick steps:
 
 ::
 
+  conda activate insilichem
+
+or
+
+::
+
   source activate insilichem
 
 5 - Run it!

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,7 @@ Quick steps:
 
 ::
 
-  conda create -n insilichem -c omnia -c salilab -c insilichem -c anaconda -c bioconda gaudi
+  conda create -n insilichem -c omnia -c salilab -c insilichem -c conda-forge -c bioconda gaudi
 
 
 4 - Activate the new environment as proposed:

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - omnia
 - salilab
 - bioconda
-- anaconda
+- conda-forge
 dependencies:
 - python=2.7
 - nomkl

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 - omnia
 - salilab
 - bioconda
+- anaconda
 dependencies:
 - python=2.7
 - nomkl


### PR DESCRIPTION
This PR is to update some files, basically actualizing conda channels that are needed to install GaudiMM. Version of imp package is also updated to 2.11 because 2.9 is not available at salilab conda channel.
With these changes, the installation process works without error (tested in Ubuntu 16.04 and macOS Mojave 10.14).