### PR TITLE
Dev torsion

### DIFF
--- a/tests/test_genes_torsion.py
+++ b/tests/test_genes_torsion.py
@@ -48,7 +48,7 @@ def test_torsion(individual, path, angle, bonds, rotatable, distance):
         atom1 = individual.genes['Molecule'].compound.mol.atoms[0]
         point = individual.genes['Molecule'].compound.mol.atoms[-1].xformCoord()
         assert len(list(torsion.rotatable_bonds)) == rotatable == torsion.max_bonds == len(torsion.allele)
-        assert Distance._distance(atom1, point) == distance
+        assert abs(Distance._distance(atom1, point) - distance) < 0.0001
 
 
 @pytest.mark.parametrize("path, angle, distance", [


### PR DESCRIPTION
Now the user can establish the concrete bonds that should be able to rotate.
It can be done with the parameter ``rotatable_bonds``, which expects a list of [SerialNumberAtom1, SerialNumberAtom2, SerialNumberAnchor].
Other change:
In the case that an anchor atom in a ``search`` gene is not found, the anchor atom will be set as the nearest to the center of the molecule. If it's not possible, then the donor atom of the molecule will be used as anchor for the rotations.